### PR TITLE
Update local: new local decoders, default feat set, configuration for perceptrons (sklearn and dp)

### DIFF
--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -11,6 +11,8 @@ In the future we may move this to a proper configuration file.
 from __future__ import print_function
 import itertools as itr
 
+from numpy import inf
+
 from attelo.harness.config import (EvaluationConfig,
                                    LearnerConfig,
                                    Keyed)
@@ -20,6 +22,11 @@ from attelo.decoding.baseline import (LocalBaseline)
 from attelo.decoding.local import (AsManyDecoder, BestIncomingDecoder)
 from attelo.decoding.mst import (MstDecoder, MstRootStrategy)
 from attelo.decoding.intra import (IntraInterDecoder, IntraStrategy)
+from attelo.learning.perceptron import (Perceptron,
+                                        PerceptronArgs,
+                                        PassiveAggressive,
+                                        StructuredPerceptron,
+                                        StructuredPassiveAggressive)
 from attelo.learning import (can_predict_proba)
 from sklearn.linear_model import (LogisticRegression,
                                   Perceptron as SkPerceptron,
@@ -87,6 +94,25 @@ def learner_maxent():
     "return a keyed instance of maxent learner"
     return Keyed('maxent', LogisticRegression())
 
+LOCAL_PERC_ARGS = PerceptronArgs(iterations=20,
+                                 averaging=True,
+                                 use_prob=False,
+                                 aggressiveness=inf)
+
+LOCAL_PA_ARGS = PerceptronArgs(iterations=20,
+                               averaging=True,
+                               use_prob=False,
+                               aggressiveness=inf)
+
+STRUCT_PERC_ARGS = PerceptronArgs(iterations=50,
+                                  averaging=True,
+                                  use_prob=False,
+                                  aggressiveness=inf)
+
+STRUCT_PA_ARGS = PerceptronArgs(iterations=50,
+                                averaging=True,
+                                use_prob=False,
+                                aggressiveness=inf)
 
 _LOCAL_LEARNERS = [
     LearnerConfig(attach=learner_oracle(),
@@ -101,6 +127,12 @@ _LOCAL_LEARNERS = [
 #    LearnerConfig(attach=Keyed('sk-pasagg',
 #                               SkPassiveAggressiveClassifier(n_iter=20)),
 #                  relate=learner_maxent()),
+#    LearnerConfig(attach=Keyed('dp-perc',
+#                               Perceptron(d, LOCAL_PERC_ARGS)),
+#                  relate=learner_maxent()),
+#    LearnerConfig(attach=Keyed('dp-pa',
+#                               PassiveAggressive(d, LOCAL_PA_ARGS)),
+#                  relate=learner_maxent()),
 ]
 """Straightforward attelo learner algorithms to try
 
@@ -110,8 +142,12 @@ between different configurations of your learners.
 """
 
 _STRUCTURED_LEARNERS = [
-    # lambda d: LearnerConfig(attach=Keyed('pd-perceptron', Perceptron(d)),
-    #                        relate=learner_maxent(),
+#    lambda d: LearnerConfig(attach=Keyed('dp-struct-perc',
+#                                         StructuredPerceptron(d, STRUCT_PERC_ARGS)),
+#                            relate=learner_maxent()),
+#    lambda d: LearnerConfig(attach=Keyed('dp-struct-pa',
+#                                         StructuredPassiveAggressive(d, STRUCT_PA_ARGS)),
+#                            relate=learner_maxent()),
 ]
 
 """Attelo learners that take decoders as arguments.

--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -60,7 +60,7 @@ Where to read the Penn Treebank from (should be dir corresponding to
 parsed/mrg/wsj)
 """
 
-FEATURE_SET = 'li2014'  # one of ['dev', 'eyk', 'li2014']
+FEATURE_SET = 'dev'  # one of ['dev', 'eyk', 'li2014']
 """
 Which feature set to use for feature extraction
 """

--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -17,6 +17,7 @@ from attelo.harness.config import (EvaluationConfig,
 
 from attelo.decoding import (DecodingMode)
 from attelo.decoding.baseline import (LocalBaseline)
+from attelo.decoding.local import (AsManyDecoder, BestIncomingDecoder)
 from attelo.decoding.mst import (MstDecoder, MstRootStrategy)
 from attelo.decoding.intra import (IntraInterDecoder, IntraStrategy)
 from attelo.learning import (can_predict_proba)
@@ -118,7 +119,9 @@ We assume that they cannot be used relation modelling
 
 _CORE_DECODERS = [
     Keyed('local', decoder_local),
-    Keyed('mst', decoder_mst)
+    Keyed('mst', decoder_mst),
+#    Keyed('asmany', lambda _: AsManyDecoder()),
+#    Keyed('bestin', lambda _: BestIncomingDecoder()),
 ]
 
 """Attelo decoders to try in experiment

--- a/irit_rst_dt/local.py
+++ b/irit_rst_dt/local.py
@@ -95,9 +95,11 @@ _LOCAL_LEARNERS = [
                   relate=learner_maxent()),
     LearnerConfig(attach=learner_maxent(),
                   relate=learner_oracle()),
-#    LearnerConfig(attach=Keyed('sk-perceptron', SkPerceptron()),
+#    LearnerConfig(attach=Keyed('sk-perceptron',
+#                               SkPerceptron(n_iter=20)),
 #                  relate=learner_maxent()),
-#    LearnerConfig(attach=Keyed('sk-pasagg', SkPassiveAggressiveClassifier()),
+#    LearnerConfig(attach=Keyed('sk-pasagg',
+#                               SkPassiveAggressiveClassifier(n_iter=20)),
 #                  relate=learner_maxent()),
 ]
 """Straightforward attelo learner algorithms to try


### PR DESCRIPTION
This PR updates `irit_rst_dt.local` to catch up with recent and ongoing changes in attelo:
* new local decoders, cf. kowey/attelo#23
* use the currently developped feature set `dev` by default,
* set sklearn's perceptron and passive aggressive to run for 20 iterations,
* proper configuration for the structured perceptron and passive aggressive